### PR TITLE
Add configurable user-agent string, defaults to Firefox 122 on Linux

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -13,3 +13,5 @@ POST_TEMPLATE=post.txt.jinja
 
 MASTODON_SECRET=secrets/usercred.secret
 MASTODON_API_BASE_URL=
+
+USER_AGENT="Mozilla/5.0 (Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,15 @@
             "args": ["--multiple-feeds", "--debug"],
             "console": "integratedTerminal",
             "justMyCode": true
+        },
+        {
+            "name": "Python: podcast_bot.py --multiple-feeds --dry-run",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/podcast_bot.py",
+            "args": ["--multiple-feeds", "--debug", "--dry-run"],
+            "console": "integratedTerminal",
+            "justMyCode": true
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Once the dependencies have been installed, make a copy of the `.env.dist` file a
 | MAX_EPISODES | Maximum number of episodes to retrieve from the podcast feed and process. (Default: 50) |
 | MAX_DESCRIPTION_LENGTH | Maximum length (in characters) of the podcast episode description to be included in the post. (Default: 275) |
 | PODCAST_GUID_FILTER | String used as a filter episode GUIDs values to include and exclude GUIDs that to not include the string. |
+| USER_AGENT | User Agent string to provide when retrieving a podcast feed. (Default: User Agent string for Firefox 122 on Linux). |
 | POST_TEMPLATE_DIR | Path for the directory containing the Jinja2 template file. |
 | POST_TEMPLATE | Path for the Jinja2 template file that will be used to format the post. |
 
@@ -78,6 +79,7 @@ The `feeds.json` file needs to be a valid JSON file that contains an array of ob
 | podcast_guid_filter | String used as a filter episode GUIDs values to include and exclude GUIDs that to not include the string. |
 | mastodon_secret | OAuth secret file that will be used to authenticate your Mastodon user account against your Mastodon server. |
 | mastodon_api_base_url | The base API URL for your Mastodon instance. Refer to your Mastodon instance for the appropriate URL to use. |
+| user_agent | User Agent string to provide when retrieving a podcast feed. (Default: User Agent string for Firefox 122 on Linux). |
 | template_directory | Path for the directory containing the Jinja2 template file. |
 | template_file | Path for the Jinja2 template file that will be used to format the post. |
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -27,6 +27,9 @@ class FeedSettings(NamedTuple):
     max_episodes: int = 50
     max_description_length: int = 275
     guid_filter: str = None
+    user_agent: str = (
+        "Mozilla/5.0 (Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0"
+    )
     template_directory: str = "templates"
     template_file: str = "post.txt.jinja"
 
@@ -75,6 +78,10 @@ class AppConfig:
                 max_episodes=int(feed.get("max_episodes", 50)),
                 max_description_length=int(feed.get("max_description_length", 275)),
                 guid_filter=feed.get("podcast_guid_filter", "").strip(),
+                user_agent=feed.get(
+                    "user_agent",
+                    "Mozilla/5.0 (Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0",
+                ).strip(),
                 template_directory=feed.get("template_directory", "templates").strip(),
                 template_file=feed.get("template_file", "post.txt.jinja").strip(),
             )
@@ -121,6 +128,10 @@ class AppEnvironment:
                 dotenv_config.get("MAX_DESCRIPTION_LENGTH", 275)
             ),
             guid_filter=dotenv_config.get("PODCAST_GUID_FILTER", "").strip(),
+            user_agent=dotenv_config.get(
+                "USER_AGENT",
+                "Mozilla/5.0 (Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0",
+            ).strip(),
             template_directory=dotenv_config.get(
                 "POST_TEMPLATE_DIR", "templates"
             ).strip(),

--- a/feed/__init__.py
+++ b/feed/__init__.py
@@ -4,8 +4,8 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Podcast Feed Module."""
-import urllib.request
 from typing import Any
+from urllib import request
 
 import podcastparser
 
@@ -13,11 +13,17 @@ import podcastparser
 class PodcastFeed:
     """Podcast Feed Fetcher."""
 
-    def fetch(self, feed_url: str, max_episodes: int = 50) -> list[dict[str, Any]]:
+    def fetch(
+        self,
+        feed_url: str,
+        max_episodes: int = 50,
+        user_agent="Mozilla/5.0 (Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0",
+    ) -> list[dict[str, Any]]:
         """Fetch items from the requested podcast feed."""
+        feed_request = request.Request(url=feed_url, headers={"User-Agent": user_agent})
         feed: dict[str, Any] = podcastparser.parse(
             url=feed_url,
-            stream=urllib.request.urlopen(feed_url),
+            stream=request.urlopen(feed_request),
             max_episodes=max_episodes,
         )
         return feed["episodes"]

--- a/feeds.dist.json
+++ b/feeds.dist.json
@@ -12,6 +12,7 @@
         "podcast_guid_filter": null,
         "mastodon_secret": "",
         "mastodon_api_base_url": "",
+        "user_agent": "Mozilla/5.0 (Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0",
         "template_directory": "templates",
         "template_file": "post.txt.jinja"
     }

--- a/podcast_bot.py
+++ b/podcast_bot.py
@@ -20,7 +20,7 @@ from db import FeedDatabase
 from feed import PodcastFeed
 from mastodon_client import MastodonClient
 
-APP_VERSION: str = "1.0.0"
+APP_VERSION: str = "1.1.0"
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -190,7 +190,9 @@ def main() -> None:
         # Pull episodes from the configured podcast feed
         podcast: PodcastFeed = PodcastFeed()
         episodes: list[dict[str, Any]] = podcast.fetch(
-            feed_url=feed.feed_url, max_episodes=feed.max_episodes
+            feed_url=feed.feed_url,
+            max_episodes=feed.max_episodes,
+            user_agent=feed.user_agent,
         )
         logger.debug(f"Feed URL: {feed.feed_url}")
 
@@ -215,7 +217,7 @@ def main() -> None:
             logger.debug(f"New Episodes:\n{pformat(new_episodes)}")
 
             for episode in new_episodes:
-                episode["title"]: str = unsmart_quotes(text=episode["title"])
+                episode["title"] = unsmart_quotes(text=episode["title"])
                 post_text: str = format_post(
                     podcast_name=feed.podcast_name,
                     episode=episode,


### PR DESCRIPTION
Add support for customizable user agent string used by `podcastparser` and `urllib` to retrieve a podcast feed. The default string is set to `Mozilla/5.0 (Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0`.